### PR TITLE
Listen address is now attribute driven, non-static configuration file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,12 @@ end
 # redhat, centos, fedora, scientific, debian, ubuntu
 default['snmp']['service'] = 'snmpd'
 
+default['snmp']['conffile'] = '/etc/snmp/snmpd.conf'
+default['snmp']['conf_owner'] = 'root'
+default['snmp']['conf_group'] = 'root'
+default['snmp']['conf_mode'] = 0600
+default['snmp']['agentAddress'] = 'udp:161'
+default['snmp']['agentAddress6'] = 'udp6:161'
 default['snmp']['community'] = 'public'
 default['snmp']['sec_name'] = { 'notConfigUser' => %w(default) }
 default['snmp']['sec_name6'] = { 'notConfigUser' => %w(default) }

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,10 +37,11 @@ node['snmp']['groups']['v1'].each_key { |key| groupnames << key }
 node['snmp']['groups']['v2c'].each_key { |key| groupnames << key }
 groupnames = groupnames.uniq
 
-template '/etc/snmp/snmpd.conf' do
-  mode 00600
-  owner 'root'
-  group 'root'
+template node['snmp']['conffile'] do
+  source 'snmpd.conf.erb'
+  mode node['snmp']['conf_mode']
+  owner node['snmp']['conf_owner']
+  group node['snmp']['conf_group']
   variables(groups: groupnames)
   notifies :restart, "service[#{node['snmp']['service']}]"
 end

--- a/templates/default/snmpd.conf.erb
+++ b/templates/default/snmpd.conf.erb
@@ -8,7 +8,7 @@
 ###############################################################################
 #
 
-agentAddress udp:161<% if node.key?('ip6address') -%>,udp6:161<% end -%>
+agentAddress <%= node['snmp']['agentAddress'] %><% if node.key?('ip6address') -%>,<%= node['snmp']['agentAddress6'] %><% end -%>
 
 ###############################################################################
 # Access Control


### PR DESCRIPTION
Corrects the following bug ids:
- #10 - Enable only listening on a specific address/network
- #37 - Static snmpd.conf configuration file location

Moves the listen address and configuration file location to attributes.
