### PR TITLE
Enable agentx configuration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,6 +65,7 @@ default['snmp']['disks'] = []
 default['snmp']['load_average'] = []
 default['snmp']['extend_scripts'] = {}
 
+
 # Debian default file options
 default['snmp']['snmpd']['mibdirs'] = '/usr/share/snmp/mibs'
 default['snmp']['snmpd']['mibs'] = nil
@@ -75,3 +76,4 @@ default['snmp']['snmpd']['snmpd_opts'] = '-Lsd -Lf /dev/null -u snmp -g snmp -I 
 default['snmp']['snmpd']['trapd_run'] = 'no'
 default['snmp']['snmpd']['trapd_opts'] = '-Lsd -p /var/run/snmptrapd.pid'
 default['snmp']['snmpd']['snmpd_compat'] = 'yes'
+default['snmp']['snmpd']['agentxsocket'] = 'no'

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'snmp'
 maintainer 'Thomas Vincent'
 maintainer_email 'thomasvincent@gmail.com'
 license 'Apache-2.0'
-version '4.0.1'
+version '4.0.2'
 description 'Installs and configures snmpd'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/thomasvincent/cookbook-snmp'

--- a/templates/default/snmpd.conf.erb
+++ b/templates/default/snmpd.conf.erb
@@ -173,6 +173,9 @@ trapsink <%= trapsink %>
 <% if node['snmp']['snmpd']['trapd_run'] == "yes" %>
 master agentx
 <% end %>
+<% if node['snmp']['snmpd']['agentxsocket'] != "no" %>
+agentxsocket <%= node['snmp']['snmpd']['agentxsocket'] %>
+<% end %>
 
 ###############################################################################
 # Extend Section


### PR DESCRIPTION
1. Added option to enable agentx socket for external agentx integration.
2. Minor version bump to show this change.

### Description

Added the agentxsocket option to snmpd configuration for integration with Quagga/FRR.

### Issues Resolved

n/a

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
